### PR TITLE
feat: Add mem report command for external MCP integration

### DIFF
--- a/memov/core/git.py
+++ b/memov/core/git.py
@@ -286,14 +286,27 @@ class GitManager:
         return commit_hash
 
     @staticmethod
-    def git_show(bare_repo: str, commit_id: str) -> None:
-        """Show details of a specific snapshot in the memov bare repo, similar to git show."""
+    def git_show(bare_repo: str, commit_id: str, return_output: bool = False) -> Optional[str]:
+        """Show details of a specific snapshot in the memov bare repo, similar to git show.
+
+        Args:
+            bare_repo: Path to the bare git repository
+            commit_id: Commit hash to show
+            return_output: If True, return the output as a string instead of printing
+
+        Returns:
+            If return_output is True, returns the git show output as a string, otherwise None
+        """
         command = ["git", f"--git-dir={bare_repo}", "show", commit_id]
         success, output = subprocess_call(command=command)
 
-        sys.stdout.write(output.stdout)
-        if output.stderr:
-            sys.stderr.write(output.stderr)
+        if return_output:
+            return output.stdout if success else ""
+        else:
+            sys.stdout.write(output.stdout)
+            if output.stderr:
+                sys.stderr.write(output.stderr)
+            return None
 
     @staticmethod
     def get_commit_history(bare_repo: str, tip: str) -> list[str]:


### PR DESCRIPTION
##  Changes:
  - Added report() method to MemovManager class that retrieves the latest commit's metadata including commit hash, diff, branch name, parent commit, and associated
   prompt/response data
  - Implemented mem report CLI command with JSON and text output formats
  - Enhanced GitManager.git_show() to optionally return output as a string instead of printing to stdout
  - Fixed parent commit detection logic to correctly identify the second-to-last commit in history

##  Use Case:
  External MCP servers can now query memov repositories to obtain all necessary commit parameters (commit_hash, diff, branch, parent_commit, commit_message)
  required for uploading to cloud-based version control systems. This eliminates the need for complex bash parsing and provides a reliable programmatic interface.

 ## Testing:
  Verified functionality with test repository creation, file tracking, and report generation in both JSON and text formats.
  
cc  @crispyberry 